### PR TITLE
cjn-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,18 @@ If you want to delete a playlist or song from a playlist, it must be removed fro
 4. Run PPP with Python 3
 
 ```
-PPP.py [-h] [-setup] [-nobackups] [-retention n]
+usage: PPP.py [-h] [-setup] [-nobackups] [-retention n] [-nocleanup]
+
+PPP v3.0.1 cjn. Syncs playlists between Plex and a local directory containing
+.m3u playlist files.
 
 optional arguments:
   -h, --help    show this help message and exit
   -setup        Force-run the setup procedure
   -nobackups    Disable backup of local playlists completely!
   -retention n  Number of previous local playlist backups to keep (Default 10)
-  ```
+  -nocleanup    Disable removal of .tmp directory (for debug)
+```
 ---
 
 ## Setup


### PR DESCRIPTION
V3.0.1 feedback
- My environment...  running PPP on Centos 7 on Python 3.7.  The Plex server is on the same machine, as is the music collection.  Using MediaMonkey on Windows as the source of my playlists that I want to port to Plex (not editing playlists in Plex currently).  MediaMonkey (via Samba) and Plex see the same music files on the Linux disk, and MediaMonkey writes/exports the playlists onto the shared Linux disk.
- Several edits that are self-obvious.
- The regex matchs always failed for me.  Added 'r' to the re strings.  Also add letters to the URL match.
- I was thrown by the non-echo'd input of the token, so I changed the token input to a regular input.  The token is in clear text in the .json file, and not echoed during non-setup runs, so…
-  If Plex has no playlists then this code blows up with `IndexError: list index out of range` for the keys[0] term.  Added check for a Plex playlist, which needs to have at least two different artist tracks (not checked but noted) in order to correctly determine the plex common path.
```
    print("Fetching sample playlist to determine prepend...")
	    _, playlist = plexPlaylist(server_url, plex_token, keys[0])
```
- os.path.commonpath only works correctly when the current machine type is same as the paths being evaluated.  If mixed platforms then the correct target version needs to be used (ntpath or posixpath).
- If a playlist to be imported has Latin-1 chars then this `# Look for playlists` code blows up.  Once such a local playlist has been read in the code writes it back out as utf8, so all the other file reads seem stable.  I implemented readPlaylistFile and used for the two cases of initially reading local playlists.  readPlaylistFile could perhaps be used for all playlist reads.
```
    playlist = io.open(
                   os.path.join(root, file), 'r', encoding='utf8').read().splitlines()
```
- When variables.json does not exist then setupVariables is run in the exception.  If there is an exception within setupVariables, such as the above Latin-1 encoding, then there is a nested exception which isn't handled.  I changed the top level to simply check for the existence of the variables.json, and call setupVariables if it does not exist.
- The local_prepend got built as `""`.  My local playlists came out of MediaMonkey from Windows, so track names look like `Z:\media\Music\cjnMusic\Raconteurs - Hands\Raconteurs, The - 02 - Intimate Secretary.mp3`.  The empty local_prepend may have been caused by the next comment issue, and the above commonpath issue.
- MediaMonkey playlists have comment lines that need to be filtered out, or the written .m3u has the local_prepend on every line, including the comment lines.  Plex nicely ignores lines when the path to the track can't be found.  readPlaylistFile fixes this by stripping out comment lines.
```
Original…
#EXTM3U
#EXTINF:448,David Bromberg - Mr. Bojangles
Z:\media\Music\cjnMusic\Bromberg, David - Out of the Blues; Best of David Bromberg\04 - Mr. Bojangles.mp3
#EXTINF:193,Jamie Stillway - Domisomido
Z:\media\Music\cjnMusic\Stillway, Jamie - Mell of a Hess\01 - Domisomido.mp3
```

```
As processed before changes…
Z:\media\Music\cjnMusic#EXTM3U
Z:\media\Music\cjnMusic#EXTINF:448,David Bromberg - Mr. Bojangles
Z:\media\Music\cjnMusic\Bromberg, David - Out of the Blues; Best of David Bromberg\04 - Mr. Bojangles.mp3
Z:\media\Music\cjnMusic#EXTINF:193,Jamie Stillway - Domisomido
Z:\media\Music\cjnMusic\Stillway, Jamie - Mell of a Hess\01 - Domisomido.mp3
```
- One remaining issue (that I may have introduced):  If I create a playlist in Plex then after the PPP run that playlist gets duplicated in Plex, rather than seen as the same by Plex.  Perhaps Plex sees a difference with what it has for that playlist name and what PPP is uploading.

