### PR TITLE
Add more error reporting and robustness, pull common code into a function, etc

### DIFF
--- a/example-variables.json
+++ b/example-variables.json
@@ -1,9 +1,10 @@
-{
+
     "server_url": "http://192.168.1.100:32400",
     "check_ssl": "True",
     "plex_token": "A1B3c4bdHA3s8COTaE3l",
     "local_playlists": "/mnt/Playlists",
-    "install_directory": "/mnt/PPP",
+    "working_directory": "/mnt/PPP",
+    "working_directory_plex": "/mnt/PPP",
     "section_id": "11",
     "local_prepend": "Z:\\Media\\Music\\",
     "plex_prepend": "/mnt/Media/Music",


### PR DESCRIPTION
- Pull common Plex requests into a function with more error reporting on failures.
  - Reuses code.
  - Provides errors on server failures or forbidden when plex token is wrong.
  - `raise SystemExit` if a request fails without an exception rather than carrying on.
  - Use requests module's ok definition and status_code/reason for errors without outputting HTML.
  Fetch a second playlist if there is one to extend detection
 - If (like on my system) the first playlist happens to be all one artist prefix detection fails. Try two if there is more than one playlist.
- Add an indent to pretty-print the `variables.json` file when it is output to make it more human readable/editable after the fact.
- Give more detail on reasons loading an existing `variables.json` file may have failed.
- Exit when failing to read existing `variables.json` file.
- Switch quoting on one line to not need to escape single quotes and remove unneeded escaping.
- Detect and give a more visible warning before exit when updating plex playlists fails (such as when the directory isn't readable by plex).

- Update example variables file to current variable names.