### PR TITLE
fixed logic error in w2u path conversion

### DIFF
--- a/PPP.py
+++ b/PPP.py
@@ -426,7 +426,7 @@ def setupFolders():
 def convertPath(path, convert, invert):
     if convert == False:
         return path
-    elif convert == ('w2u' and not invert) or ('u2w' and invert):
+    elif (convert == 'w2u' and not invert) or (convert == 'u2w' and invert):
         return path.replace("/", "\\")
     else:
         return path.replace("\\", "/")


### PR DESCRIPTION
Experienced an issue when running PPP on windows and sending local playlists to a remote Plex Server running in Linux. 
Apparently `convertPath()` could not reach `path.replace("/", "\\")` due to this logic error. 

This change fixed it for me.

My Python version is 3.8.8 (in case this logic error is version specific)

